### PR TITLE
Logger custom output format

### DIFF
--- a/Sources/HeliumLogger/HeliumLogger.swift
+++ b/Sources/HeliumLogger/HeliumLogger.swift
@@ -24,29 +24,44 @@ public enum TerminalColor: String {
     case Background = "\u{001B}[0;49m" // default background color
 }
 
+public enum HeliumLoggerFormatValues: String {
+    case Message = "(%m)"
+    case Function = "(%func)"
+    case Line = "(%l)"
+    case File = "(%file)"
+    case LogType = "(%t)"
+
+    static let All = [.Message, .Function, .Line, .File, .LogType]
+}
+
 public class HeliumLogger {
-    
-    /// 
+
+    ///
     /// Singleton instance of the logger
     // static public var logger: Logger?
-    
+
     public var colored: Bool = true
-    
+
     public var details: Bool = true
-    
+
+    public var format: String?
+
+    private let detailedFormat = "(%t): (%func) (%file) line (%l) - (%m)"
+    private let defaultFormat = "(%t): (%m)"
+
     public init () {}
-    
-    
+
+
 
 }
 
 extension HeliumLogger : Logger {
-    
+
     public func log(type: LoggerMessageType, msg: String,
         functionName: String, lineNum: Int, fileName: String ) {
-            
+
             var color : TerminalColor = .Foreground
-            
+
             if type == .Warning {
                 color = .Yellow
             } else if type == .Error {
@@ -54,7 +69,7 @@ extension HeliumLogger : Logger {
             } else {
                 color = .Foreground
             }
-            
+
             if colored && details {
                 print ("\(color.rawValue) \(type.rawValue): \(functionName) \(fileName) line \(lineNum) - \(msg) \(TerminalColor.Foreground.rawValue)")
             } else if !colored && details {
@@ -64,6 +79,6 @@ extension HeliumLogger : Logger {
             } else {
                 print (" \(type.rawValue): \(msg)")
             }
-            
+
     }
 }

--- a/Sources/HeliumLogger/HeliumLogger.swift
+++ b/Sources/HeliumLogger/HeliumLogger.swift
@@ -61,14 +61,15 @@ extension HeliumLogger : Logger {
     public func log(type: LoggerMessageType, msg: String,
         functionName: String, lineNum: Int, fileName: String ) {
 
-            var color : TerminalColor = .Foreground
+            let color : TerminalColor// = .Foreground
 
-            if type == .Warning {
-                color = .Yellow
-            } else if type == .Error {
-                color = .Red
-            } else {
-                color = .Foreground
+            switch type {
+                case .Warning:
+                    color = .Yellow
+                case .Error:
+                    color = .Red
+                default:
+                    color = .Foreground
             }
 
             var message: String = self.format ?? (self.details ? HeliumLogger.detailedFormat : HeliumLogger.defaultFormat)

--- a/Sources/HeliumLogger/HeliumLogger.swift
+++ b/Sources/HeliumLogger/HeliumLogger.swift
@@ -95,10 +95,18 @@ extension HeliumLogger : Logger {
                           let date = NSDate()
                           let dateFormatter = NSDateFormatter()
                           dateFormatter.dateFormat = self.dateFormat ?? HeliumLogger.defaultDateFormat
-                          replaceValue = dateFormatter.string(from: date)
+                          #if os(Linux)
+                              replaceValue = dateFormatter.stringFromDate(date)
+                          #else
+                              replaceValue = dateFormatter.string(from: date)
+                          #endif
                 }
 
-                message = message.replacingOccurrences(of: stringValue, with: replaceValue)
+                #if os(Linux)
+                    message = message.stringByReplacingOccurrencesOfString(stringValue, with: replaceValue)
+                #else
+                    message = message.replacingOccurrences(of: stringValue, with: replaceValue)
+                #endif
             }
 
             if colored {

--- a/Sources/HeliumLogger/HeliumLogger.swift
+++ b/Sources/HeliumLogger/HeliumLogger.swift
@@ -15,6 +15,7 @@
  **/
 
 import LoggerAPI
+import Foundation
 
 public enum TerminalColor: String {
     case White = "\u{001B}[0;37m" // white
@@ -31,7 +32,7 @@ public enum HeliumLoggerFormatValues: String {
     case File = "(%file)"
     case LogType = "(%t)"
 
-    static let All = [.Message, .Function, .Line, .File, .LogType]
+    static let All: [HeliumLoggerFormatValues] = [.Message, .Function, .Line, .File, .LogType]
 }
 
 public class HeliumLogger {
@@ -46,8 +47,8 @@ public class HeliumLogger {
 
     public var format: String?
 
-    private let detailedFormat = "(%t): (%func) (%file) line (%l) - (%m)"
-    private let defaultFormat = "(%t): (%m)"
+    private static let detailedFormat = "(%t): (%func) (%file) line (%l) - (%m)"
+    private static let defaultFormat = "(%t): (%m)"
 
     public init () {}
 
@@ -70,14 +71,31 @@ extension HeliumLogger : Logger {
                 color = .Foreground
             }
 
-            if colored && details {
-                print ("\(color.rawValue) \(type.rawValue): \(functionName) \(fileName) line \(lineNum) - \(msg) \(TerminalColor.Foreground.rawValue)")
-            } else if !colored && details {
-                print (" \(type.rawValue): \(functionName) \(fileName) line \(lineNum) - \(msg)")
-            } else if colored && !details {
-                print ("\(color.rawValue) \(type.rawValue): \(msg) \(TerminalColor.White.rawValue)")
+            var message: String = self.format ?? (self.details ? HeliumLogger.detailedFormat : HeliumLogger.defaultFormat)
+
+            for formatValue in HeliumLoggerFormatValues.All {
+                let stringValue = formatValue.rawValue
+                let replaceValue: String
+                switch formatValue {
+                      case .LogType:
+                          replaceValue = type.rawValue
+                      case .Message:
+                          replaceValue = msg
+                      case .Function:
+                          replaceValue = functionName
+                      case .Line:
+                          replaceValue = "\(lineNum)"
+                      case .File:
+                          replaceValue = fileName
+                }
+
+                message = message.replacingOccurrences(of: stringValue, with: replaceValue)
+            }
+
+            if colored {
+                print ("\(color.rawValue) \(message) \(TerminalColor.Foreground.rawValue)")
             } else {
-                print (" \(type.rawValue): \(msg)")
+                print (" \(message) ")
             }
 
     }

--- a/Sources/HeliumLogger/HeliumLogger.swift
+++ b/Sources/HeliumLogger/HeliumLogger.swift
@@ -103,7 +103,7 @@ extension HeliumLogger : Logger {
                 }
 
                 #if os(Linux)
-                    message = message.stringByReplacingOccurrencesOfString(stringValue, with: replaceValue)
+                    message = message.stringByReplacingOccurrencesOfString(stringValue, withString: replaceValue)
                 #else
                     message = message.replacingOccurrences(of: stringValue, with: replaceValue)
                 #endif

--- a/Sources/HeliumLogger/HeliumLogger.swift
+++ b/Sources/HeliumLogger/HeliumLogger.swift
@@ -26,13 +26,16 @@ public enum TerminalColor: String {
 }
 
 public enum HeliumLoggerFormatValues: String {
-    case Message = "(%m)"
+    case Message = "(%msg)"
     case Function = "(%func)"
-    case Line = "(%l)"
+    case Line = "(%line)"
     case File = "(%file)"
-    case LogType = "(%t)"
+    case LogType = "(%type)"
+    case Date = "(%date)"
 
-    static let All: [HeliumLoggerFormatValues] = [.Message, .Function, .Line, .File, .LogType]
+    static let All: [HeliumLoggerFormatValues] = [
+        .Message, .Function, .Line, .File, .LogType, .Date
+    ]
 }
 
 public class HeliumLogger {
@@ -46,14 +49,13 @@ public class HeliumLogger {
     public var details: Bool = true
 
     public var format: String?
+    public var dateFormat: String?
 
-    private static let detailedFormat = "(%t): (%func) (%file) line (%l) - (%m)"
-    private static let defaultFormat = "(%t): (%m)"
+    private static let detailedFormat = "(%type): (%func) (%file) line (%line) - (%msg)"
+    private static let defaultFormat = "(%type): (%msg)"
+    private static let defaultDateFormat = "dd.MM.YYYY, HH:mm:ss"
 
     public init () {}
-
-
-
 }
 
 extension HeliumLogger : Logger {
@@ -61,7 +63,7 @@ extension HeliumLogger : Logger {
     public func log(type: LoggerMessageType, msg: String,
         functionName: String, lineNum: Int, fileName: String ) {
 
-            let color : TerminalColor// = .Foreground
+            let color : TerminalColor
 
             switch type {
                 case .Warning:
@@ -87,7 +89,13 @@ extension HeliumLogger : Logger {
                       case .Line:
                           replaceValue = "\(lineNum)"
                       case .File:
-                          replaceValue = fileName
+                          let fileNameUrl = NSURL(string: fileName)
+                          replaceValue = fileNameUrl?.lastPathComponent ?? fileName
+                      case .Date:
+                          let date = NSDate()
+                          let dateFormatter = NSDateFormatter()
+                          dateFormatter.dateFormat = self.dateFormat ?? HeliumLogger.defaultDateFormat
+                          replaceValue = dateFormatter.string(from: date)
                 }
 
                 message = message.replacingOccurrences(of: stringValue, with: replaceValue)
@@ -98,6 +106,5 @@ extension HeliumLogger : Logger {
             } else {
                 print (" \(message) ")
             }
-
     }
 }


### PR DESCRIPTION
Implemented some features from IBM-Swift/Kitura#358. 
Added custom log format and changed output of ```filename``` from full path to actual file name.