### PR TITLE
Develop

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,6 @@ import PackageDescription
 let package = Package(
     name: "HeliumLogger",
     dependencies: [
-        .Package(url: "https://github.com/IBM-Swift/LoggerAPI.git", majorVersion: 0, minor: 7),
+        .Package(url: "https://github.com/tkhuran/LoggerAPI.git", majorVersion: 0, minor: 8),
     ]
 )

--- a/Sources/HeliumLogger/HeliumLogger.swift
+++ b/Sources/HeliumLogger/HeliumLogger.swift
@@ -56,6 +56,11 @@ public class HeliumLogger {
     private static let defaultDateFormat = "dd.MM.YYYY, HH:mm:ss"
 
     public init () {}
+    
+    private var type: LoggerMessageType = .verbose
+    public init (_ type: LoggerMessageType) {
+        self.type = type
+    }
 }
 
 extension HeliumLogger : Logger {
@@ -101,10 +106,12 @@ extension HeliumLogger : Logger {
                 message = message.replacingOccurrences(of: stringValue, with: replaceValue)
             }
 
-            if colored {
-                print ("\(color.rawValue) \(message) \(TerminalColor.foreground.rawValue)")
-            } else {
-                print (" \(message) ")
-            }
+            if type.logValue() >= self.type.logValue() {
+                if colored {
+                    print ("\(color.rawValue) \(message) \(TerminalColor.foreground.rawValue)")
+                } else {
+                    print (" \(message) ")
+                }
+        }
     }
 }

--- a/Tests/HeliumLogger/TestLogger.swift
+++ b/Tests/HeliumLogger/TestLogger.swift
@@ -33,6 +33,7 @@ class TestLogger : XCTestCase {
                    ("testInfo", testInfo),
                    ("testWarning", testWarning),
                    ("testError", testError),
+                   ("testLevel", testLevel),
         ]
     }
     
@@ -51,6 +52,16 @@ class TestLogger : XCTestCase {
     
     func testError() {
         Log.logger = HeliumLogger()
+        Log.error("This is an error")
+        
+    }
+    
+    func testLevel() {
+        Log.logger = HeliumLogger(.warning)
+        Log.verbose("This is an verbose")
+        Log.info("This is an info")
+        Log.debug("This is an debug")
+        Log.warning("This is an warning")
         Log.error("This is an error")
         
     }

--- a/Tests/HeliumLogger/TestLogger.swift
+++ b/Tests/HeliumLogger/TestLogger.swift
@@ -58,10 +58,10 @@ class TestLogger : XCTestCase {
     
     func testLevel() {
         Log.logger = HeliumLogger(.warning)
-        Log.verbose("This is an verbose")
+        Log.verbose("This is a verbose")
         Log.info("This is an info")
-        Log.debug("This is an debug")
-        Log.warning("This is an warning")
+        Log.debug("This is a debug")
+        Log.warning("This is a warning")
         Log.error("This is an error")
         
     }


### PR DESCRIPTION
LoggerAPI and HeliumLogger currently does not support log level controlling.

## Description

Example:
An app development life cycle goes from Dev -> Test -> Staging - > Prod. Now chart below shows the log levels for each of the environment that a developer wants to use, staring from Dev (maximum logging) to the Prod with the least logging (only the errors).

| Environment | Log Levels |
| -------- | -------- |
| DEV   | .Verbose  |
| TEST   | .Debug   |
| STAGE   | .Warning   |
| PROD   | .Error   |

## Motivation and Context
The proposed changes will the fix the issue of working with a single code base in multiple development environments without commenting/ uncommenting the Logs.

https://github.com/IBM-Swift/LoggerAPI/issues/7

## How Has This Been Tested?
This is tested by added a Unit Test Case inside the ```TestLogger.swift```
```swift
func testLevel() {
        Log.logger = HeliumLogger(.warning)
        Log.verbose("This is a verbose")
        Log.info("This is an info")
        Log.debug("This is a debug")
        Log.warning("This is a warning")
        Log.error("This is an error")
    }
```
The output with the LogLevel = .warning
This is a warning
This is an error

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ `x` ] If applicable, I have added tests to cover my changes.
