### PR TITLE
Disable buffering on STDOUT for CF logs to show log messages

### DIFF
--- a/Sources/HeliumLogger/HeliumLogger.swift
+++ b/Sources/HeliumLogger/HeliumLogger.swift
@@ -59,6 +59,7 @@ public class HeliumLogger {
 
     public static func use() {
         Log.logger = HeliumLogger()
+        setbuf(stdout, nil)
     }
     
     private var type: LoggerMessageType = .verbose


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses the problem that CF logs does not produce output of our Log messages.

<!--- Describe your changes in detail -->

## Motivation and Context

Bluemix does not output the Log messages. This is because of buffering. There is a reported fix that involves [disabling buffering on standard out](http://stackoverflow.com/questions/37900068/swift-print-to-system-out-on-bluemix). 

## How Has This Been Tested?

This has not been tested yet because it involves an actual Bluemix deployment.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.

In order for STDOUT to appear in Bluemix we need