### PR TITLE
Updates to the HeliumLogger to take into account changes made to LoggerAPI

### DIFF
--- a/Sources/HeliumLogger/HeliumLogger.swift
+++ b/Sources/HeliumLogger/HeliumLogger.swift
@@ -91,7 +91,7 @@ extension HeliumLogger : Logger {
                 let replaceValue: String
                 switch formatValue {
                       case .logType:
-                          replaceValue = type.rawValue
+                          replaceValue = type.description
                       case .message:
                           replaceValue = msg
                       case .function:
@@ -116,7 +116,7 @@ extension HeliumLogger : Logger {
                 message = message.replacingOccurrences(of: stringValue, with: replaceValue)
             }
 
-            if type.logValue() >= self.type.logValue() {
+            if type.rawValue >= self.type.rawValue {
                 if colored {
                     print ("\(color.rawValue) \(message) \(TerminalColor.foreground.rawValue)")
                 } else {

--- a/Tests/HeliumLogger/TestLogger.swift
+++ b/Tests/HeliumLogger/TestLogger.swift
@@ -46,7 +46,7 @@ class TestLogger : XCTestCase {
     
     func testWarning() {
         Log.logger = HeliumLogger()
-        Log.warning("This is an warning")
+        Log.warning("This is a warning")
         
     }
     

--- a/Tests/HeliumLogger/TestLogger.swift
+++ b/Tests/HeliumLogger/TestLogger.swift
@@ -40,13 +40,13 @@ class TestLogger : XCTestCase {
     
     func testInfo() {
         Log.logger = HeliumLogger()
-        Log.info("This is an error")
+        Log.info("This is an info")
         
     }
     
     func testWarning() {
         Log.logger = HeliumLogger()
-        Log.warning("This is an error")
+        Log.warning("This is an warning")
         
     }
     


### PR DESCRIPTION
## Description
Use LoggerMessageType.rawValue to compare types in filetering. Use LoggerMessageType.description to get a printable format.

The LoggerAPI PR https://github.com/IBM-Swift/LoggerAPI/pull/10 needs to be merged and tagged before this PR is merged.

## Motivation and Context
Make the code more Swifty.

## How Has This Been Tested?
Ran test suite.

## Checklist:

- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
