### PR TITLE
IBM-Swift/Kitura#922 Enhance features and performance of HeliumLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # HeliumLogger
 
 [![Build Status](https://travis-ci.org/IBM-Swift/HeliumLogger.svg?branch=master)](https://travis-ci.org/IBM-Swift/HeliumLogger)
+[![codecov](https://codecov.io/gh/IBM-Swift/HeliumLogger/branch/master/graph/badge.svg)](https://codecov.io/gh/IBM-Swift/HeliumLogger)
 
 Provides a lightweight Swift Logging framework.
 

--- a/Sources/HeliumLogger/HeliumLogger.swift
+++ b/Sources/HeliumLogger/HeliumLogger.swift
@@ -92,7 +92,7 @@ public class HeliumLogger {
     }
 
     /// default date format - ISO 8601
-    public static let defaultDateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+    public static let defaultDateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
 
     fileprivate var dateFormatter: DateFormatter = HeliumLogger.getDateFormatter()
 

--- a/Tests/HeliumLoggerTests/TestLogger.swift
+++ b/Tests/HeliumLoggerTests/TestLogger.swift
@@ -46,7 +46,10 @@ class TestLogger : XCTestCase {
                     ("testParseFormatEndingWithLiteral", testParseFormatEndingWithLiteral),
                     ("testParseFormatWithNoLiterals", testParseFormatWithNoLiterals),
                     ("testParseFormatWithRepeatedTokens", testParseFormatWithRepeatedTokens),
-                    ("testGetFile", testGetFile)
+                    ("testLogSegmentEquality", testLogSegmentEquality),
+                    ("testGetFile", testGetFile),
+                    ("testFormatDates", testFormatDates),
+                    ("testFormatEntries", testFormatEntries)
         ]
     }
     
@@ -89,6 +92,8 @@ class TestLogger : XCTestCase {
         Log.debug("This is a debug")
         Log.warning("This is a warning")
         Log.error("This is an error")
+
+        HeliumLogger(.info).log(.debug, msg: "THIS SHOULD NOT BE RENDERED", functionName: #function, lineNum: #line, fileName: #file)
     }
 
     func testIsLogging () {
@@ -205,6 +210,18 @@ class TestLogger : XCTestCase {
         XCTAssertEqual(segments, parsedSegments)
     }
 
+    func testLogSegmentEquality() {
+        let dateEnum = HeliumLoggerFormatValues.date
+        let literal1 = HeliumLogger.LogSegment.literal(dateEnum.rawValue)
+        let literal2 = HeliumLogger.LogSegment.literal("(%date)")
+        let token1 = HeliumLogger.LogSegment.token(dateEnum)
+        let token2 = HeliumLogger.LogSegment.token(HeliumLoggerFormatValues(rawValue: dateEnum.rawValue)!)
+
+        XCTAssertEqual(literal1, literal2)
+        XCTAssertEqual(token1, token2)
+        XCTAssertNotEqual(literal1, token1)
+    }
+
     func testGetFile() {
         let filePath = #file
         let url = URL(fileURLWithPath: filePath)
@@ -215,5 +232,85 @@ class TestLogger : XCTestCase {
 
         logger.fullFilePath = false
         XCTAssertEqual(url.lastPathComponent, logger.getFile(filePath))
+
+        let filePathWithoutSlashes = filePath.replacingOccurrences(of: "/", with: "_")
+        XCTAssertEqual(filePathWithoutSlashes, logger.getFile(filePathWithoutSlashes))
+    }
+
+    func testFormatDates() {
+        let date = Date()
+        let dateFormat = "MM/dd/yyyy'test'HH:mm:ss.SSSSSSSSS"
+        let timeZone = TimeZone(secondsFromGMT: TimeZone.current.secondsFromGMT() + 3600)
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = dateFormat
+
+        let logger = HeliumLogger()
+        XCTAssertNotEqual(formatter.string(from: date), logger.formatDate(date)) // different formats
+
+        logger.dateFormat = dateFormat
+        formatter.timeZone = timeZone
+        XCTAssertNotEqual(formatter.string(from: date), logger.formatDate(date)) // different time zones
+
+        logger.timeZone = timeZone
+        XCTAssertEqual(formatter.string(from: date), logger.formatDate(date)) // now everything should be the same
+    }
+
+    func testFormatEntries() {
+        let logger = HeliumLogger()
+        logger.dateFormat = "" // short circuit date so we can compare entries generated at different times
+
+        let type: LoggerMessageType = .error
+        let msg = "test message"
+        let file = #file
+        let line = #line
+        let funct = #function
+
+        logger.fullFilePath = false
+        logger.colored = false
+
+        logger.details = false
+        let shortFormat = logger.formatEntry(type: type, msg: msg, functionName: funct, lineNum: line, fileName: file)
+        logger.details = true
+        let longFormat = logger.formatEntry(type: type, msg: msg, functionName: funct, lineNum: line, fileName: file)
+
+        let format   = "!!!TEST!!! [(%file):(%line) (%msg) (%func)](%date)"
+        let expected = "!!!TEST!!! [\(file):\(line) \(msg) \(funct)]"
+        logger.format = format
+
+        // test custom format with fullFilePath = false
+        XCTAssertNotEqual(expected, logger.formatEntry(type: type, msg: msg, functionName: funct, lineNum: line, fileName: file))
+
+        logger.fullFilePath = true
+        // test custom format with fullFilePath = true
+        XCTAssertEqual(expected, logger.formatEntry(type: type, msg: msg, functionName: funct, lineNum: line, fileName: file))
+
+        // test custom formats are the same when not colorized for different log types
+        XCTAssertEqual(expected, logger.formatEntry(type: .warning, msg: msg, functionName: funct, lineNum: line, fileName: file))
+        XCTAssertEqual(expected, logger.formatEntry(type: .info, msg: msg, functionName: funct, lineNum: line, fileName: file))
+        XCTAssertEqual(expected, logger.formatEntry(type: .error, msg: msg, functionName: funct, lineNum: line, fileName: file))
+
+        logger.format = format + "(%type)"
+        logger.colored = true
+        let colorizedExpected = "\(TerminalColor.red.rawValue)\(expected)\(type)\(TerminalColor.foreground.rawValue)"
+
+        // test custom formats are NOT the same when not colorized for different log types
+        XCTAssertNotEqual(colorizedExpected, logger.formatEntry(type: .warning, msg: msg, functionName: funct, lineNum: line, fileName: file))
+        XCTAssertNotEqual(colorizedExpected, logger.formatEntry(type: .info, msg: msg, functionName: funct, lineNum: line, fileName: file))
+        XCTAssertEqual(colorizedExpected, logger.formatEntry(type: type, msg: msg, functionName: funct, lineNum: line, fileName: file))
+
+        // test formatted entries are NOT the same as defaults when logger.format is set
+        XCTAssertNotEqual(shortFormat, logger.formatEntry(type: type, msg: msg, functionName: funct, lineNum: line, fileName: file))
+        XCTAssertNotEqual(longFormat, logger.formatEntry(type: type, msg: msg, functionName: funct, lineNum: line, fileName: file))
+
+        logger.format = nil
+        logger.fullFilePath = false
+        logger.colored = false
+
+        // test formatted entries are the same as defaults when logger.format is nil
+        logger.details = false
+        XCTAssertEqual(shortFormat, logger.formatEntry(type: type, msg: msg, functionName: funct, lineNum: line, fileName: file))
+        logger.details = true
+        XCTAssertEqual(longFormat, logger.formatEntry(type: type, msg: msg, functionName: funct, lineNum: line, fileName: file))
     }
 }


### PR DESCRIPTION
## Description
Enhance features and performance of HeliumLogger (IBM-Swift/Kitura#922)

## Motivation and Context
- Currently HeliumLogger's detailed and basic default formats do not log date/time, which should be logged by default.
- HeliumLogger formats the log message using multiple calls of string.replacingOccurrences(of). The same thing can be done much more efficiently using string interpolation or appending pre-parsed log segments.
- The default date format is "dd.MM.YYYY, HH:mm:ss". It should be in line with standard date formatting and use "yyyy-MM-dd'T'HH:mm:ss.SSS"
- Currently the check if we actually need to log based on the log level is done at the end. It should be the first thing we check
- Getting the filename from the filepath is currently done by creating a NSURL object. It is more efficient to use string.substring()
- Give users the ability to specify the time zone for the date/time

## How Has This Been Tested?
Logging a message a million times (commenting out the final print in log()) and checking the time taken:
On linux running in docker I reliably got approximately:
```
current master:
Default: 406.472931027412 seconds

This PR:
Default: 6.76490998268127 seconds
No details: 4.81400203704834 seconds
User specified: 8.68355000019073 seconds
```
On mac I reliably got approximately:
```
current master:
Default: 89.0834839940071 seconds

This PR:
Default: 10.601704955101 seconds
No details: 7.9820299744606 seconds
User specified: 14.4082700014114 seconds
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.