### PR TITLE
Add test for Mac vs Linux test count. Randomize test order on Linux. …

### DIFF
--- a/Tests/HeliumLoggerTests/VerifyLinuxTestCount.swift
+++ b/Tests/HeliumLoggerTests/VerifyLinuxTestCount.swift
@@ -1,0 +1,36 @@
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#if os(OSX)
+    import XCTest
+    
+    class VerifyLinuxTestCount: XCTestCase {
+        func testVerifyLinuxTestCount() {
+            var linuxCount: Int
+            var darwinCount: Int
+            
+            // TestLogger
+            linuxCount = TestLogger.allTests.count
+            darwinCount = Int(TestLogger.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestLogger.allTests")
+            
+            // TestStreamLogger
+            linuxCount = TestStreamLogger.allTests.count
+            darwinCount = Int(TestStreamLogger.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestStreamLogger.allTests")
+        }
+    }
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -18,13 +18,14 @@ import XCTest
 import Glibc
 @testable import HeliumLoggerTests
 
+srand(UInt32(time(nil)))
+
 // http://stackoverflow.com/questions/24026510/how-do-i-shuffle-an-array-in-swift
 extension MutableCollection where Indices.Iterator.Element == Index {
     mutating func shuffle() {
         let c = count
         guard c > 1 else { return }
-        
-        srand(UInt32(time(nil)))
+
         for (firstUnshuffled , unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
             let d: IndexDistance = numericCast(random() % numericCast(unshuffledCount))
             guard d != 0 else { continue }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -15,10 +15,34 @@
  **/
 
 import XCTest
-
+import Glibc
 @testable import HeliumLoggerTests
 
+// http://stackoverflow.com/questions/24026510/how-do-i-shuffle-an-array-in-swift
+extension MutableCollection where Indices.Iterator.Element == Index {
+    mutating func shuffle() {
+        let c = count
+        guard c > 1 else { return }
+        
+        srand(UInt32(time(nil)))
+        for (firstUnshuffled , unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
+            let d: IndexDistance = numericCast(random() % numericCast(unshuffledCount))
+            guard d != 0 else { continue }
+            let i = index(firstUnshuffled, offsetBy: d)
+            swap(&self[firstUnshuffled], &self[i])
+        }
+    }
+}
+
+extension Sequence {
+    func shuffled() -> [Iterator.Element] {
+        var result = Array(self)
+        result.shuffle()
+        return result
+    }
+}
+
 XCTMain([
-    testCase(TestLogger.allTests),
-    testCase(TestStreamLogger.allTests),
-    ])
+    testCase(TestLogger.allTests.shuffled()),
+    testCase(TestStreamLogger.allTests.shuffled()),
+    ].shuffled())


### PR DESCRIPTION
…IBM-Swift/Kitura#1056

## Description
- Add a test class that checks if every other test class has included all their tests in their `allTests` var
- Add extensions in `LinuxMain.swift` to shuffle an array, and shuffle the order that the test classes are run, as well as the tests within the classes

## Motivation and Context
[#1056](https://github.com/IBM-Swift/Kitura/issues/1056)

## How Has This Been Tested?
OSX: Swift 3.1
Linux: Swift 3.1 & Swift 3.0.2