### PR TITLE
Change in PackageDescription

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:4.2
+
 /**
  * Copyright IBM Corporation 2016, 2017
  *
@@ -19,6 +21,6 @@ import PackageDescription
 let package = Package(
     name: "HeliumLogger",
     dependencies: [
-        .Package(url: "https://github.com/IBM-Swift/LoggerAPI.git", majorVersion: 1, minor: 7),
+        .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.3")
     ]
 )


### PR DESCRIPTION
PackageDescription API has been changed from v3 to v4.

-Addition of // swift-tools-version:4.2 line in the package.
-Some syntactical changes to change the version of PackageDesciprtion form v3 to v4 

- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
