### PR TITLE
Add support for using HeliumLogger as a SwiftLog backend

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,9 @@ let package = Package(
         )
     ],
     dependencies: [
+        // Note: Syntax to allow compatibility with both Swift 4 and Swift 5 projects.
+        // See: https://github.com/apple/swift-log#help-i-need-swift-4
+        .package(url: "https://github.com/apple/swift-log.git", Version("0.0.0") ..< Version("2.0.0")),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.0")
     ],
     targets: [
@@ -36,7 +39,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "HeliumLogger",
-            dependencies: ["LoggerAPI"]),
+            dependencies: ["Logging", "LoggerAPI"]),
         .testTarget(
             name: "HeliumLoggerTests",
             dependencies: ["HeliumLogger"])

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -29,6 +29,9 @@ let package = Package(
         )
     ],
     dependencies: [
+        // Note: Syntax to allow compatibility with both Swift 4 and Swift 5 projects.
+        // See: https://github.com/apple/swift-log#help-i-need-swift-4
+        .package(url: "https://github.com/apple/swift-log.git", Version("0.0.0") ..< Version("2.0.0")),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.0")
     ],
     targets: [
@@ -36,7 +39,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "HeliumLogger",
-            dependencies: ["LoggerAPI"]),
+            dependencies: ["Logging", "LoggerAPI"]),
         .testTarget(
             name: "HeliumLoggerTests",
             dependencies: ["HeliumLogger"])

--- a/Sources/HeliumLogger/HeliumLogHandler.swift
+++ b/Sources/HeliumLogger/HeliumLogHandler.swift
@@ -1,0 +1,113 @@
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+import Logging
+
+public extension HeliumLogger {
+    
+    /// Creates a `HeliumLogHandler` instance for use with the SwiftLog logging system.
+    ///
+    ///### Usage Example: ###
+    /// This may be used to bootstrap the SwiftLog logging system with a
+    /// `HeliumLogger` instance. The `HeliumLogger` instance will
+    /// be used as the logging backend for SwiftLog.
+    ///```swift
+    ///let heliumLogger = HeliumLogger()
+    ///LoggingSystem.bootstrap(heliumLogger.makeLogHandler)
+    ///```
+    /// - Parameter label: The label to use for a SwiftLog `Logger`.
+    func makeLogHandler(label: String) -> HeliumLogHandler {
+        return HeliumLogHandler(label: label, logger: self)
+    }
+    
+    private static let defaultLogger: HeliumLogger = {
+        return HeliumLogger()
+    }()
+    
+    /// Creates a `HeliumLogHandler` instance for use with the SwiftLog logging system.
+    ///
+    ///### Usage Example: ###
+    /// This may be used to bootstrap the SwiftLog logging system with a default
+    /// `HeliumLogger` instance. The default `HeliumLogger` instance will
+    /// be used as the logging backend for SwiftLog.
+    ///```swift
+    ///LoggingSystem.bootstrap(HeliumLogger.makeLogHandler)
+    ///```
+    /// - Parameter label: The label to use for a SwiftLog `Logger`.
+    static func makeLogHandler(label: String) -> HeliumLogHandler {
+        return HeliumLogHandler(label: label, logger: defaultLogger)
+    }
+}
+
+/// A lightweight implementation of SwiftLog's `LogHandler` protocol.
+public struct HeliumLogHandler: LogHandler {
+    public var logger: HeliumLogger
+    
+    public let label: String
+    
+    public var logLevel: Logger.Level = .info
+    
+    private var prettyMetadata: String?
+    
+    public var metadata = Logger.Metadata() {
+        didSet {
+            prettyMetadata = prettify(metadata)
+        }
+    }
+    
+    public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
+        get {
+            return metadata[metadataKey]
+        }
+        set {
+            metadata[metadataKey] = newValue
+        }
+    }
+    
+    init(label: String, logger: HeliumLogger) {
+        self.label = label
+        self.logger = logger
+    }
+    
+    public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {
+        let prettyMetadata = metadata?.isEmpty ?? true
+            ? self.prettyMetadata
+            : self.prettify(self.metadata.merging(metadata!, uniquingKeysWith: { _, new in new }))
+        
+        let output = logger.formatEntry(type: "\(level)", label: label, msg: "\(message)", metadata: prettyMetadata, color: level.color,
+                                        functionName: function, lineNum: Int(line), fileName: file)
+        
+        logger.doPrint(output)
+    }
+    
+    private func prettify(_ metadata: Logger.Metadata) -> String? {
+        return !metadata.isEmpty ? metadata.map { "\($0)=\($1)" }.joined(separator: " ") : nil
+    }
+}
+
+extension Logger.Level {
+    var color: TerminalColor {
+        switch self {
+        case .warning:
+            return .yellow
+        case .error:
+            return .red
+        default:
+            return .foreground
+        }
+    }
+}

--- a/Sources/HeliumLogger/HeliumLogHandler.swift
+++ b/Sources/HeliumLogger/HeliumLogHandler.swift
@@ -34,9 +34,7 @@ public extension HeliumLogger {
         return HeliumLogHandler(label: label, logger: self)
     }
     
-    private static let defaultLogger: HeliumLogger = {
-        return HeliumLogger()
-    }()
+    private static let defaultLogger = HeliumLogger()
     
     /// Creates a `HeliumLogHandler` instance for use with the SwiftLog logging system.
     ///

--- a/Sources/HeliumLogger/HeliumLogHandler.swift
+++ b/Sources/HeliumLogger/HeliumLogHandler.swift
@@ -76,9 +76,9 @@ extension HeliumLogger {
 
 /// A lightweight implementation of SwiftLog's `LogHandler` protocol.
 public struct HeliumLogHandler: LogHandler {
-    public var logger: HeliumLogger
+    private let logger: HeliumLogger
     
-    public let label: String
+    private let label: String
     
     public var logLevel: Logger.Level = .info
     

--- a/Sources/HeliumLogger/HeliumLogHandler.swift
+++ b/Sources/HeliumLogger/HeliumLogHandler.swift
@@ -19,6 +19,29 @@ import Logging
 
 extension HeliumLogger {
     
+    /// A one-time configuration function to bootstrap the SwiftLog logging system
+    /// using `HeliumLogger` as the logging backend.
+    ///
+    ///### Usage Example: ###
+    /// This bootstraps the SwiftLog logging system with a default
+    /// `HeliumLogger` instance. The default `HeliumLogger` instance will
+    /// be used as the logging backend for SwiftLog.
+    ///```swift
+    ///HeliumLogger.bootstrapSwiftLog()
+    ///```
+    ///
+    /// It's also possible to customize the default `HeliumLogger` instance using a configuration closure.
+    ///```swift
+    ///HeliumLogger.bootstrapSwiftLog { heliumLogger in
+    ///    heliumLogger.colored = true
+    ///}
+    ///```
+    /// - Parameter configure: An optional closure that may be used to configure the default `HeliumLogger` instance.
+    public static func bootstrapSwiftLog(_ configure: ((HeliumLogger) -> Void)? = nil) {
+        configure?(defaultLogger)
+        LoggingSystem.bootstrap(HeliumLogger.makeLogHandler)
+    }
+    
     /// Creates a `HeliumLogHandler` instance for use with the SwiftLog logging system.
     ///
     ///### Usage Example: ###

--- a/Sources/HeliumLogger/HeliumLogHandler.swift
+++ b/Sources/HeliumLogger/HeliumLogHandler.swift
@@ -17,7 +17,7 @@
 import Foundation
 import Logging
 
-public extension HeliumLogger {
+extension HeliumLogger {
     
     /// Creates a `HeliumLogHandler` instance for use with the SwiftLog logging system.
     ///
@@ -30,7 +30,7 @@ public extension HeliumLogger {
     ///LoggingSystem.bootstrap(heliumLogger.makeLogHandler)
     ///```
     /// - Parameter label: The label to use for a SwiftLog `Logger`.
-    func makeLogHandler(label: String) -> HeliumLogHandler {
+    public func makeLogHandler(label: String) -> HeliumLogHandler {
         return HeliumLogHandler(label: label, logger: self)
     }
     
@@ -46,7 +46,7 @@ public extension HeliumLogger {
     ///LoggingSystem.bootstrap(HeliumLogger.makeLogHandler)
     ///```
     /// - Parameter label: The label to use for a SwiftLog `Logger`.
-    static func makeLogHandler(label: String) -> HeliumLogHandler {
+    public static func makeLogHandler(label: String) -> HeliumLogHandler {
         return HeliumLogHandler(label: label, logger: defaultLogger)
     }
 }

--- a/Sources/HeliumLogger/HeliumLogger.swift
+++ b/Sources/HeliumLogger/HeliumLogger.swift
@@ -47,7 +47,7 @@ public enum HeliumLoggerFormatValues: String {
     /// The time and date at which the message was logged.
     case date = "(%date)"
     
-    static let All: [HeliumLoggerFormatValues] = [
+    static let all: [HeliumLoggerFormatValues] = [
         .message, .function, .line, .file, .logType, .date
     ]
 }
@@ -60,7 +60,7 @@ public enum HeliumLoggerSwiftLogFormatValues: String {
     /// The label of the logger used by SwiftLog.
     case label = "(%label)"
     
-    static let All: [HeliumLoggerSwiftLogFormatValues] = [
+    static let all: [HeliumLoggerSwiftLogFormatValues] = [
         .metadata, .label
     ]
 }

--- a/Tests/HeliumLoggerTests/TestLogger.swift
+++ b/Tests/HeliumLoggerTests/TestLogger.swift
@@ -47,6 +47,8 @@ class TestLogger : XCTestCase {
                     ("testParseFormatWithNoLiterals", testParseFormatWithNoLiterals),
                     ("testParseFormatWithRepeatedTokens", testParseFormatWithRepeatedTokens),
                     ("testLogSegmentEquality", testLogSegmentEquality),
+                    ("testSwiftLogLogSegmentEquality", testSwiftLogLogSegmentEquality),
+                    ("testUniqueLogFormatRawValues", testUniqueLogFormatRawValues),
                     ("testGetFile", testGetFile),
                     ("testFormatDates", testFormatDates),
                     ("testFormatEntries", testFormatEntries)
@@ -173,8 +175,8 @@ class TestLogger : XCTestCase {
 
     func testParseFormatWithNoLiterals() {
         let logSegments: [HeliumLogger.LogSegment] = [
-            .token(.label),
-            .token(.metadata),
+            .swiftLogToken(.label),
+            .swiftLogToken(.metadata),
             .token(.date),
             .token(.logType),
             .token(.file),
@@ -187,8 +189,8 @@ class TestLogger : XCTestCase {
 
     func testParseFormatWithRepeatedTokens() {
         let logSegments: [HeliumLogger.LogSegment] = [
-            .token(.label),
-            .token(.metadata),
+            .swiftLogToken(.label),
+            .swiftLogToken(.metadata),
             .token(.date),
             .token(.file),
             .token(.date),
@@ -207,6 +209,8 @@ class TestLogger : XCTestCase {
                 format.append(literal)
             case .token(let token):
                 format.append(token.rawValue)
+            case .swiftLogToken(let token):
+                format.append(token.rawValue)
             }
         }
 
@@ -224,6 +228,24 @@ class TestLogger : XCTestCase {
         XCTAssertEqual(literal1, literal2)
         XCTAssertEqual(token1, token2)
         XCTAssertNotEqual(literal1, token1)
+    }
+    
+    func testSwiftLogLogSegmentEquality() {
+        let labelEnum = HeliumLoggerSwiftLogFormatValues.label
+        let literal1 = HeliumLogger.LogSegment.literal(labelEnum.rawValue)
+        let literal2 = HeliumLogger.LogSegment.literal("(%label)")
+        let token1 = HeliumLogger.LogSegment.swiftLogToken(labelEnum)
+        let token2 = HeliumLogger.LogSegment.swiftLogToken(HeliumLoggerSwiftLogFormatValues(rawValue: labelEnum.rawValue)!)
+        
+        XCTAssertEqual(literal1, literal2)
+        XCTAssertEqual(token1, token2)
+        XCTAssertNotEqual(literal1, token1)
+    }
+    
+    func testUniqueLogFormatRawValues() {
+        let standardFormatRawValues = Set(HeliumLoggerFormatValues.All.map { $0.rawValue })
+        let swiftLogFormatRawValues = Set(HeliumLoggerSwiftLogFormatValues.All.map { $0.rawValue })
+        XCTAssert(standardFormatRawValues.isDisjoint(with: swiftLogFormatRawValues))
     }
 
     func testGetFile() {

--- a/Tests/HeliumLoggerTests/TestLogger.swift
+++ b/Tests/HeliumLoggerTests/TestLogger.swift
@@ -173,6 +173,8 @@ class TestLogger : XCTestCase {
 
     func testParseFormatWithNoLiterals() {
         let logSegments: [HeliumLogger.LogSegment] = [
+            .token(.label),
+            .token(.metadata),
             .token(.date),
             .token(.logType),
             .token(.file),
@@ -185,6 +187,8 @@ class TestLogger : XCTestCase {
 
     func testParseFormatWithRepeatedTokens() {
         let logSegments: [HeliumLogger.LogSegment] = [
+            .token(.label),
+            .token(.metadata),
             .token(.date),
             .token(.file),
             .token(.date),

--- a/Tests/HeliumLoggerTests/TestLogger.swift
+++ b/Tests/HeliumLoggerTests/TestLogger.swift
@@ -243,8 +243,8 @@ class TestLogger : XCTestCase {
     }
     
     func testUniqueLogFormatRawValues() {
-        let standardFormatRawValues = Set(HeliumLoggerFormatValues.All.map { $0.rawValue })
-        let swiftLogFormatRawValues = Set(HeliumLoggerSwiftLogFormatValues.All.map { $0.rawValue })
+        let standardFormatRawValues = Set(HeliumLoggerFormatValues.all.map { $0.rawValue })
+        let swiftLogFormatRawValues = Set(HeliumLoggerSwiftLogFormatValues.all.map { $0.rawValue })
         XCTAssert(standardFormatRawValues.isDisjoint(with: swiftLogFormatRawValues))
     }
 

--- a/Tests/HeliumLoggerTests/TestSwiftLog.swift
+++ b/Tests/HeliumLoggerTests/TestSwiftLog.swift
@@ -1,0 +1,115 @@
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+import HeliumLogger
+import Logging
+
+let isLoggingConfigured: Bool = {
+    let heliumLogger = HeliumLogger()
+    LoggingSystem.bootstrap(heliumLogger.makeLogHandler)
+    return true
+}()
+
+class TestSwiftLog: XCTestCase {
+    
+    static var allTests : [(String, (TestSwiftLog) -> () throws -> Void)] {
+        return [
+            ("testTrace", testTrace),
+            ("testDebug", testDebug),
+            ("testInfo", testInfo),
+            ("testNotice", testNotice),
+            ("testWarning", testWarning),
+            ("testError", testError),
+            ("testLevel", testLevel),
+            ("testCritical", testCritical),
+            ("testValueSemantics", testValueSemantics)
+        ]
+    }
+
+    override func setUp() {
+        XCTAssert(isLoggingConfigured)
+    }
+    
+    func testTrace() {
+        var logger = Logger(label: "TraceLogger")
+        logger.logLevel = .trace
+        logger.trace("This is a trace")
+    }
+    
+    func testDebug() {
+        var logger = Logger(label: "DebugLogger")
+        logger.logLevel = .debug
+        logger.debug("This is a debug")
+    }
+    
+    func testInfo() {
+        let logger = Logger(label: "InfoLogger")
+        logger.info("This is an info")
+    }
+    
+    func testNotice() {
+        let logger = Logger(label: "NoticeLogger")
+        logger.notice("This is a notice")
+    }
+    
+    func testWarning() {
+        let logger = Logger(label: "WarningLogger")
+        logger.warning("This is a warning")
+    }
+    
+    func testError() {
+        let logger = Logger(label: "ErrorLogger")
+        logger.error("This is an error")
+    }
+    
+    func testCritical() {
+        let logger = Logger(label: "CriticalLogger")
+        logger.critical("This is a critical")
+    }
+    
+    func testLevel() {
+        var logger = Logger(label: "WarningLogger")
+        logger.logLevel = .warning
+        logger.trace("THIS SHOULD NOT BE RENDERED")
+        logger.debug("THIS SHOULD NOT BE RENDERED")
+        logger.info("THIS SHOULD NOT BE RENDERED")
+        logger.notice("THIS SHOULD NOT BE RENDERED")
+        logger.warning("This is a warning")
+        logger.error("This is an error")
+        logger.critical("This is a critical")
+    }
+    
+    func testValueSemantics() {
+        var logger1 = Logger(label: "first logger")
+        logger1.logLevel = .debug
+        logger1[metadataKey: "only-on"] = "first"
+        
+        var logger2 = logger1
+        logger2.logLevel = .error
+        logger2[metadataKey: "only-on"] = "second"
+        
+        logger1.debug("This is a debug")
+        logger2.debug("THIS SHOULD NOT BE RENDERED")
+        logger2.error("This is an error")
+        
+        XCTAssertEqual(.debug, logger1.logLevel)
+        XCTAssertEqual(.error, logger2.logLevel)
+        XCTAssertEqual("first", logger1[metadataKey: "only-on"])
+        XCTAssertEqual("second", logger2[metadataKey: "only-on"])
+    }
+
+}

--- a/Tests/HeliumLoggerTests/TestSwiftLog.swift
+++ b/Tests/HeliumLoggerTests/TestSwiftLog.swift
@@ -19,8 +19,7 @@ import HeliumLogger
 import Logging
 
 let isLoggingConfigured: Bool = {
-    let heliumLogger = HeliumLogger()
-    LoggingSystem.bootstrap(heliumLogger.makeLogHandler)
+    HeliumLogger.bootstrapSwiftLog()
     return true
 }()
 

--- a/Tests/HeliumLoggerTests/TestSwiftLog.swift
+++ b/Tests/HeliumLoggerTests/TestSwiftLog.swift
@@ -96,11 +96,11 @@ class TestSwiftLog: XCTestCase {
     func testValueSemantics() {
         var logger1 = Logger(label: "first logger")
         logger1.logLevel = .debug
-        logger1[metadataKey: "only-on"] = "first"
+        logger1[metadataKey: "only-on"] = .string("first")
         
         var logger2 = logger1
         logger2.logLevel = .error
-        logger2[metadataKey: "only-on"] = "second"
+        logger2[metadataKey: "only-on"] = .string("second")
         
         logger1.debug("This is a debug")
         logger2.debug("THIS SHOULD NOT BE RENDERED")
@@ -108,8 +108,8 @@ class TestSwiftLog: XCTestCase {
         
         XCTAssertEqual(.debug, logger1.logLevel)
         XCTAssertEqual(.error, logger2.logLevel)
-        XCTAssertEqual("first", logger1[metadataKey: "only-on"])
-        XCTAssertEqual("second", logger2[metadataKey: "only-on"])
+        XCTAssertEqual(.string("first"), logger1[metadataKey: "only-on"])
+        XCTAssertEqual(.string("second"), logger2[metadataKey: "only-on"])
     }
 
 }

--- a/Tests/HeliumLoggerTests/VerifyLinuxTestCount.swift
+++ b/Tests/HeliumLoggerTests/VerifyLinuxTestCount.swift
@@ -34,6 +34,11 @@
             linuxCount = TestStreamLogger.allTests.count
             darwinCount = Int(TestStreamLogger.defaultTestSuite().testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestStreamLogger.allTests")
+            
+            // TestSwiftLog
+            linuxCount = TestSwiftLog.allTests.count
+            darwinCount = Int(TestSwiftLog.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestSwiftLog.allTests")
         }
     }
 #endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -62,4 +62,5 @@ extension Sequence {
 XCTMain([
     testCase(TestLogger.allTests.shuffled()),
     testCase(TestStreamLogger.allTests.shuffled()),
+    testCase(TestSwiftLog.allTests.shuffled()),
     ].shuffled())


### PR DESCRIPTION
This adds support for using HeliumLogger as a [SwiftLog](https://github.com/apple/swift-log) backend.

## Description
### Bootstrap SwiftLog
This makes it possible to bootstrap the SwiftLog logging system in a few different ways.

**Convenience API**
There is a convenience API to bootstrap SwiftLog using HeliumLogger.

```swift
HeliumLogger.bootstrapSwiftLog()
```

You may optionally customize the default `HeliumLogger` instance used with SwiftLog using a configuration closure.
```swift
HeliumLogger.bootstrapSwiftLog { heliumLogger in
    heliumLogger.colored = true
}
```

**LoggingSystem API**

You can bootstrap the SwiftLog logging system directly using a static factory method on `HeliumLogger`.

```
LoggingSystem.bootstrap(HeliumLogger.makeLogHandler)
```

Alternatively, you can bootstrap using an existing `HeliumLogger` instance. This allows for customization of the `HeliumLogger` instance.

```swift
let heliumLogger = HeliumLogger()
heliumLogger.colored = true

LoggingSystem.bootstrap(heliumLogger.makeLogHandler)
```

### Using SwiftLog

Once the logging system is bootstrapped, you can use SwiftLog's `Logger` as usual and `HeliumLogger ` will be used to generate the output.

```swift
var logger = Logger(label: "MyLogger")
logger.logLevel = .trace
logger.trace("This is a trace")
```

Example output:
```plain
[2019-07-09T20:06:41.779-07:00] [MyLogger] [trace] [TestSwiftLog.swift:50 testTrace()] This is a trace
```

## Motivation and Context
SwiftLog is primarily an API package and needs SwiftLog-compatible logging backends. 

From [SwiftLog](https://github.com/apple/swift-log#swiftlog):
> As the API has just launched, not many implementations exist yet. 
…
>This API package does actually include an overly simplistic and non-configurable logging backend implementation which simply writes all log messages to stdout.

This adds a more mature logging backend to the SwiftLog ecosystem.

## How Has This Been Tested?
I added an `XCTestCase` to test the SwiftLog implementation (`TestSwiftLog.swift`). These tests are primarily focused on exercising the new API and follows patterns from `TestLogger.swift`.

All tests are passing on macOS and Linux using Swift 4 and Swift 5 toolchains.

## Impact on Existing Code
There are no source-breaking changes to the public API.

However, this does expand the surface area of the `HeliumLogger` API and introduces potential confusion by supporting two different logging APIs with inherent differences. For example:

- `HeliumLogger` instances may be initialized using a `LoggerMessageType` that is ignored when used with SwiftLog.

- `HeliumLogger` is a class with reference semantics. SwiftLog expects a `Logger` to have value semantics. 

- Log segments were added to `HeliumLogger` that are specific to SwiftLog (`label` / `metadata`).

Longer term, it may make sense to create a generic logger package and provide separate packages for SwiftLog and LoggerAPI support, but this pull request aims to provide a much lower touch solution.

Overall, I'm hoping that the benefits of supporting the SwiftLog API are worth these tradeoffs.

Feedback welcome! 

cc @ianpartridge @djones6 